### PR TITLE
Handle change to network inspect UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ routereflector.tar
 calicobuild.created
 caliconode.created
 calico_containers/pycalico.egg-info/
+busybox.tgz
+calico-node-libnetwork.tgz
+calico-node.tgz
+calicoctl
+docker
+

--- a/tests/st/utils/utils.py
+++ b/tests/st/utils/utils.py
@@ -137,7 +137,10 @@ def get_profile_name(host, network):
     """
     info_raw = host.execute("docker network inspect %s" % network.name)
     info = json.loads(info_raw)
-    return info["id"]
+
+    # Network inspect returns a list of dicts for each network being inspected.
+    # We are only inspecting 1, so use the first entry.
+    return info[0]["id"]
 
 def assert_network(host, network):
     """


### PR DESCRIPTION
As per https://github.com/docker/docker/pull/17218 , the network inspect output has changed to return a list of dictionaries (allowing inspect to take multiple network names.

PR also includes minor updates to .gitignore.