### PR TITLE
default gw

### DIFF
--- a/libnetwork/driver_plugin.py
+++ b/libnetwork/driver_plugin.py
@@ -173,6 +173,11 @@ def join():
     endpoint_id = json_data["EndpointID"]
     app.logger.info("Joining endpoint %s", endpoint_id)
 
+    network_id = json_data["NetworkID"]
+    network_data = client.get_network(network_id)
+    gateway_net = IPNetwork(network_data['IPv4Data'][0]['Gateway'])
+    ipv4_gateway = str(gateway_net.ip)
+
     # The host interface name matches the name given when creating the endpoint
     # during CreateEndpoint
     host_interface_name = generate_cali_interface_name(IF_PREFIX, endpoint_id)
@@ -198,7 +203,7 @@ def join():
             "SrcName": temp_interface_name,
             "DstPrefix": IF_PREFIX
         },
-        "Gateway": "",  # Leave gateway empty to trigger auto-gateway behaviour
+        "Gateway": ipv4_gateway,  # Leave gateway empty to trigger auto-gateway behaviour
     }
 
     app.logger.debug("Join Response JSON=%s", return_json)

--- a/libnetwork/driver_plugin.py
+++ b/libnetwork/driver_plugin.py
@@ -175,7 +175,9 @@ def join():
 
     network_id = json_data["NetworkID"]
     network_data = client.get_network(network_id)
-    ipv4_gateway = str(IPNetwork(network_data['IPv4Data'][0]['Gateway']).ip) if "IPv4Data" in network_data.keys() else ""
+    ipv4_gateway = ""
+    if network_data and "IPv4Data" in network_data.keys():
+        ipv4_gateway = str(IPNetwork(network_data['IPv4Data'][0]['Gateway']).ip)
 
     # The host interface name matches the name given when creating the endpoint
     # during CreateEndpoint

--- a/libnetwork/driver_plugin.py
+++ b/libnetwork/driver_plugin.py
@@ -175,8 +175,7 @@ def join():
 
     network_id = json_data["NetworkID"]
     network_data = client.get_network(network_id)
-    gateway_net = IPNetwork(network_data['IPv4Data'][0]['Gateway'])
-    ipv4_gateway = str(gateway_net.ip)
+    ipv4_gateway = str(IPNetwork(network_data['IPv4Data'][0]['Gateway']).ip) if "IPv4Data" in network_data.keys() else ""
 
     # The host interface name matches the name given when creating the endpoint
     # during CreateEndpoint


### PR DESCRIPTION
The docker libnetwork will create a bridge network "docker_gwbridge" for provding  default gateway for the containers if none of the container's endpoints  have GW set by the driver.
Provide the gw in function Join.