### PR TITLE
[UT/ST Fix] Fix initiation of error handler in flask

### DIFF
--- a/libnetwork/driver_plugin.py
+++ b/libnetwork/driver_plugin.py
@@ -95,7 +95,7 @@ def make_json_app(import_name, **kwargs):
     wrapped_app = Flask(import_name, **kwargs)
 
     for code in default_exceptions.iterkeys():
-        wrapped_app.error_handler_spec[None][code] = make_json_error
+        wrapped_app.errorhandler(code)(make_json_error)
 
     return wrapped_app
 


### PR DESCRIPTION
Fix how we initiate the flask app error handler. Our old method was incompatible with the recent release of Flask 0.11+

Relevant issue:
https://github.com/pallets/flask/issues/1837#issuecomment-223359287

