### PR TITLE
Closing dockerCli to fix 'Too many open files' issue

### DIFF
--- a/driver/network_driver.go
+++ b/driver/network_driver.go
@@ -144,6 +144,7 @@ func (d NetworkDriver) CreateEndpoint(request *network.CreateEndpointRequest) (*
 		log.Errorln(err)
 		return nil, err
 	}
+	defer dockerCli.Close()
 	networkData, err := dockerCli.NetworkInspect(context.Background(), request.NetworkID)
 	if err != nil {
 		err = errors.Wrapf(err, "Network %v inspection error", request.NetworkID)


### PR DESCRIPTION
Fix for https://github.com/projectcalico/libnetwork-plugin/issues/107