### PR TITLE
Add IPv6 support

### DIFF
--- a/tests/custom_if_prefix/libnetwork_env_var_test.go
+++ b/tests/custom_if_prefix/libnetwork_env_var_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 			RunPlugin("-e CALICO_LIBNETWORK_IFPREFIX=test")
 
 			// Since running the plugin starts etcd, the pool needs to be created after.
-			CreatePool("192.169.0.0/16")
+			CreatePool("192.169.0.0/16", false)
 
 			name := fmt.Sprintf("run%d", rand.Uint32())
 			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))

--- a/tests/custom_wep_labelling/libnetwork_env_var_test.go
+++ b/tests/custom_wep_labelling/libnetwork_env_var_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 			RunPlugin("-e CALICO_LIBNETWORK_LABEL_ENDPOINTS=true")
 
 			// Since running the plugin starts etcd, the pool needs to be created after.
-			CreatePool("192.169.1.0/24")
+			CreatePool("192.169.1.0/24", false)
 
 			name := fmt.Sprintf("run%d", rand.Uint32())
 			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))
@@ -61,7 +61,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 			RunPlugin("-e CALICO_LIBNETWORK_LABEL_ENDPOINTS=true -e CALICO_LIBNETWORK_CREATE_PROFILES=false")
 
 			// Since running the plugin starts etcd, the pool needs to be created after.
-			CreatePool("192.169.2.0/24")
+			CreatePool("192.169.2.0/24", true)
 
 			name := fmt.Sprintf("run%d", rand.Uint32())
 			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))

--- a/utils/test/test_utils.go
+++ b/utils/test/test_utils.go
@@ -57,9 +57,15 @@ func GetEtcdString(path string) string {
 }
 
 // CreatePool creates a pool in etcd
-func CreatePool(pool string) {
+func CreatePool(pool string, ipv6 bool) {
+	var ipv string
+	if ipv6 {
+		ipv = "v6"
+	} else {
+		ipv = "v4"
+	}
 	_, err := kapi.Set(context.Background(),
-		fmt.Sprintf("/calico/v1/ipam/v4/pool/%s", strings.Replace(pool, "/", "-", -1)),
+		fmt.Sprintf("/calico/v1/ipam/%s/pool/%s", ipv, strings.Replace(pool, "/", "-", -1)),
 		fmt.Sprintf(`{"cidr": "%s"}`, pool), nil)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes [#72 Add (back) IPv6 support](https://github.com/projectcalico/libnetwork-plugin/issues/72).

**Usage**

1. Start the libnetwork-plugin

```
sudo dist/libnetwork-plugin
```

2. Add an IPv6 address to the host

```
sudo ip addr add fd80:24e2:f998:72d7::1/112 dev eth1
```

3. Start calico/node, without using the calico/node libnetwork-plugin, also pass in the host IPv6 address

```
sudo calicoctl node run --disable-docker-networking --ip6=fd80:24e2:f998:72d7::1
```

4. Create an IPv6 network

```
docker network create --ipv6 -d calico --ipam-driver calico-ipam my_net
```

5. Run containers on the IPv6 network

```
  docker run --net my_net --name workload-A -tid busybox
  docker run --net my_net --name workload-B -tid busybox
```


6. Check IPv6 network connectivity

```
  docker exec workload-A ping -6 -c 4 workload-B.my_net
  docker exec workload-B ping -6 -c 4 workload-A.my_net
```

7. Check IPv4 network connectivity

```
  docker exec workload-A ping -4 -c 4 workload-B.my_net
  docker exec workload-B ping -4 -c 4 workload-A.my_net
```
