### PR TITLE
ip route output now includes scope link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ endif
 	git tag $(VERSION)
 	$(MAKE) $(CONTAINER_NAME) 
 	# Check that the version output appears on a line of its own (the -x option to grep).
-# Tests that the "git tag" makes it into the binary. Main point is to catch "-dirty" builds
+	# Tests that the "git tag" makes it into the binary. Main point is to catch "-dirty" builds
 	@echo "Checking if the tag made it into the binary"
 	docker run --rm calico/libnetwork-plugin -v | grep -x $(VERSION) || (echo "Reported version:" `docker run --rm calico/libnetwork-plugin -v` "\nExpected version: $(VERSION)" && exit 1)
 	docker tag calico/libnetwork-plugin calico/libnetwork-plugin:$(VERSION)

--- a/tests/custom_if_prefix/libnetwork_env_var_test.go
+++ b/tests/custom_if_prefix/libnetwork_env_var_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev test0 \n169.254.1.1 dev test0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev test0 \n169.254.1.1 dev test0 scope link"))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))

--- a/tests/default_environment/libnetwork_test.go
+++ b/tests/default_environment/libnetwork_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
@@ -211,7 +211,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
@@ -262,7 +262,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name_subnet))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
 
 			// Delete container and network
 			DockerString(fmt.Sprintf("docker rm -f %s", name_subnet))
@@ -332,7 +332,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
 			routes6 := DockerString(fmt.Sprintf("docker exec -i %s ip -6 route", name))
 			Expect(routes6).Should(MatchRegexp("default via fe80::.* dev cali0  metric 1024"))
 


### PR DESCRIPTION
Tests failing because output from the `ip route` within the container now includes the `scope link` indication.
