### PR TITLE
Adding support for ppc64le.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
 MAINTAINER Tom Denham <tom@projectcalico.org>
-ADD dist/libnetwork-plugin-amd64 /libnetwork-plugin
+ADD dist/amd64/libnetwork-plugin /libnetwork-plugin
 ENTRYPOINT ["/libnetwork-plugin"]
 

--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -1,4 +1,4 @@
 FROM ppc64le/alpine
 MAINTAINER Tom Denham <tom@projectcalico.org>
-ADD dist/libnetwork-plugin-ppc64le /libnetwork-plugin
+ADD dist/ppc64le/libnetwork-plugin /libnetwork-plugin
 ENTRYPOINT ["/libnetwork-plugin"]

--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -1,5 +1,4 @@
-FROM alpine
+FROM ppc64le/alpine
 MAINTAINER Tom Denham <tom@projectcalico.org>
-ADD dist/libnetwork-plugin-amd64 /libnetwork-plugin
+ADD dist/libnetwork-plugin-ppc64le /libnetwork-plugin
 ENTRYPOINT ["/libnetwork-plugin"]
-

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,25 @@
+##############################################################################
+# The build architecture is select by setting the ARCH variable.
+# For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
+# When ARCH is undefined it defaults to amd64.
+ARCH?=amd64
+ifeq ($(ARCH),amd64)
+	ARCHTAG:=
+	GO_BUILD_VER?=v0.9
+	BUSYBOX_IMAGE?=busybox:latest
+	DIND_IMAGE?=docker:dind
+endif
+
+ifeq ($(ARCH),ppc64le)
+	ARCHTAG:=-ppc64le
+	GO_BUILD_VER?=latest
+	BUSYBOX_IMAGE?=ppc64le/busybox:latest
+	DIND_IMAGE?=ppc64le/docker:dind
+endif
+
 # Disable make's implicit rules, which are not useful for golang, and slow down the build
 # considerably.
 .SUFFIXES:
-
-GO_BUILD_VER?=v0.9
 
 SRC_FILES=$(shell find . -type f -name '*.go')
 
@@ -12,10 +29,10 @@ LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 |  awk '{print $$7}')
 # Can choose different docker versions see list here - https://hub.docker.com/_/docker/
 DOCKER_VERSION?=dind
 HOST_CHECKOUT_DIR?=$(CURDIR)
-CONTAINER_NAME?=calico/libnetwork-plugin
-GO_BUILD_CONTAINER?=calico/go-build:$(GO_BUILD_VER)
-PLUGIN_LOCATION?=$(CURDIR)/dist/libnetwork-plugin
-DOCKER_BINARY_CONTAINER?=docker-binary-container
+CONTAINER_NAME?=calico/libnetwork-plugin$(ARCHTAG)
+GO_BUILD_CONTAINER?=calico/go-build$(ARCHTAG):$(GO_BUILD_VER)
+PLUGIN_LOCATION?=$(CURDIR)/dist/libnetwork-plugin-$(ARCH)
+DOCKER_BINARY_CONTAINER?=docker-binary-container$(ARCHTAG)
 
 # To run with non-native docker (e.g. on Windows or OSX) you might need to overide this variable
 LOCAL_USER_ID?=$(shell id -u $$USER)
@@ -39,7 +56,8 @@ install:
 	CGO_ENABLED=0 go install github.com/projectcalico/libnetwork-plugin
 
 # Run the build in a container. Useful for CI
-dist/libnetwork-plugin: vendor
+dist/libnetwork-plugin:dist/libnetwork-plugin-$(ARCH)
+dist/libnetwork-plugin-$(ARCH): vendor
 	-mkdir -p dist
 	-mkdir -p .go-pkg-cache
 	docker run --rm \
@@ -47,15 +65,17 @@ dist/libnetwork-plugin: vendor
 		-v $(CURDIR)/dist:/go/src/github.com/projectcalico/libnetwork-plugin/dist \
 		-v $(CURDIR)/.go-pkg-cache:/go/pkg/:rw \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+		-e ARCH=$(ARCH) \
 		$(GO_BUILD_CONTAINER) sh -c '\
 			cd /go/src/github.com/projectcalico/libnetwork-plugin && \
 			make build'
 
 build: $(SRC_FILES) vendor
-	CGO_ENABLED=0 go build -v -i -o dist/libnetwork-plugin -ldflags "-X main.VERSION=$(shell git describe --tags --dirty) -s -w" main.go
+	CGO_ENABLED=0 go build -v -i -o dist/libnetwork-plugin-$(ARCH) -ldflags "-X main.VERSION=$(shell git describe --tags --dirty) -s -w" main.go
 
-$(CONTAINER_NAME): dist/libnetwork-plugin
-	docker build -t $(CONTAINER_NAME) .
+
+$(CONTAINER_NAME): dist/libnetwork-plugin-$(ARCH)
+	docker build -t $(CONTAINER_NAME) -f Dockerfile$(ARCHTAG) .
 
 # Perform static checks on the code. The golint checks are allowed to fail, the others must pass.
 .PHONY: static-checks
@@ -63,7 +83,7 @@ static-checks: vendor
 	docker run --rm \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-v $(CURDIR):/go/src/github.com/projectcalico/libnetwork-plugin \
-		calico/go-build sh -c '\
+		$(GO_BUILD_CONTAINER) sh -c '\
 			cd  /go/src/github.com/projectcalico/libnetwork-plugin && \
 			gometalinter --deadline=30s --disable-all --enable=goimports --enable=vet --enable=errcheck --enable=varcheck --enable=unused --enable=dupl $$(glide nv)'
 
@@ -71,7 +91,7 @@ run-etcd:
 	@-docker rm -f calico-etcd
 	docker run --detach \
 	--net=host \
-	--name calico-etcd quay.io/coreos/etcd \
+	--name calico-etcd quay.io/coreos/etcd:v3.2.5$(ARCHTAG) \
 	etcd \
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379" \
 	--listen-client-urls "http://0.0.0.0:2379"
@@ -85,28 +105,28 @@ endif
 	# Check that the version output appears on a line of its own (the -x option to grep).
 	# Tests that the "git tag" makes it into the binary. Main point is to catch "-dirty" builds
 	@echo "Checking if the tag made it into the binary"
-	docker run --rm calico/libnetwork-plugin -v | grep -x $(VERSION) || (echo "Reported version:" `docker run --rm calico/libnetwork-plugin -v` "\nExpected version: $(VERSION)" && exit 1)
-	docker tag calico/libnetwork-plugin calico/libnetwork-plugin:$(VERSION)
-	docker tag calico/libnetwork-plugin quay.io/calico/libnetwork-plugin:$(VERSION)
-	docker tag calico/libnetwork-plugin quay.io/calico/libnetwork-plugin:latest
+	docker run --rm calico/libnetwork-plugin$(ARCHTAG) -v | grep -x $(VERSION) || (echo "Reported version:" `docker run --rm calico/libnetwork-plugin$(ARCHTAG) -v` "\nExpected version: $(VERSION)" && exit 1)
+	docker tag calico/libnetwork-plugin$(ARCHTAG) calico/libnetwork-plugin$(ARCHTAG):$(VERSION)
+	docker tag calico/libnetwork-plugin$(ARCHTAG) quay.io/calico/libnetwork-plugin$(ARCHTAG):$(VERSION)
+	docker tag calico/libnetwork-plugin$(ARCHTAG) quay.io/calico/libnetwork-plugin$(ARCHTAG):latest
 
 	@echo "Now push the tag and images. Then create a release on Github and attach the dist/libnetwork-plugin binary"
 	@echo "git push origin $(VERSION)"
-	@echo "docker push calico/libnetwork-plugin:$(VERSION)"
-	@echo "docker push quay.io/calico/libnetwork-plugin:$(VERSION)"
-	@echo "docker push calico/libnetwork-plugin:latest"
-	@echo "docker push quay.io/calico/libnetwork-plugin:latest"
+	@echo "docker push calico/libnetwork-plugin$(ARCHTAG):$(VERSION)"
+	@echo "docker push quay.io/calico/libnetwork-plugin$(ARCHTAG):$(VERSION)"
+	@echo "docker push calico/libnetwork-plugin$(ARCHTAG):latest"
+	@echo "docker push quay.io/calico/libnetwork-plugin$(ARCHTAG):latest"
 
 clean:
-	rm -rf dist *.tar vendor docker .go-pkg-cache
+	rm -rf dist *.tar vendor .go-pkg-cache
 
-run-plugin: run-etcd dist/libnetwork-plugin
+run-plugin: run-etcd dist/libnetwork-plugin-$(ARCH)
 	-docker rm -f dind
 	docker run -tid -h test --name dind --privileged $(ADDITIONAL_DIND_ARGS) \
 		-e ETCD_ENDPOINTS=http://$(LOCAL_IP_ENV):2379 \
 		-p 5375:2375 \
 		-v $(PLUGIN_LOCATION):/libnetwork-plugin \
-		docker:$(DOCKER_VERSION) --cluster-store=etcd://$(LOCAL_IP_ENV):2379
+		$(DIND_IMAGE) --cluster-store=etcd://$(LOCAL_IP_ENV):2379
 	# View the logs by running 'docker exec dind cat plugin.log'
 	docker exec -tid --privileged dind sh -c 'sysctl -w net.ipv6.conf.default.disable_ipv6=0'
 	docker exec -tid --privileged dind sh -c '/libnetwork-plugin 2>>/plugin.log'
@@ -118,18 +138,28 @@ run-plugin: run-etcd dist/libnetwork-plugin
 test:
 	CGO_ENABLED=0 ginkgo -v tests/*
 
-test-containerized: dist/libnetwork-plugin
+# Target test-containerized needs the docker binary to be available in the go-build container.
+# Obtaining it from the docker:dind images docker should provided the latest version.  However,
+# this assumes that the go_build container has the required dependencies or that docker is static.
+# This may not be the case in all configurations. In this cases you should pre-populate ./bin
+# with a docker binary compatible with the go-build image that is used.
+bin/docker:
 	-docker rm -f $(DOCKER_BINARY_CONTAINER) 2>&1
+	mkdir -p ./bin
 	docker create --name $(DOCKER_BINARY_CONTAINER) docker:$(DOCKER_VERSION)
-	docker cp $(DOCKER_BINARY_CONTAINER):/usr/local/bin/docker .
+	docker cp $(DOCKER_BINARY_CONTAINER):/usr/local/bin/docker ./bin/docker
 	docker rm -f $(DOCKER_BINARY_CONTAINER)
-	docker run -ti --rm --net=host \
+
+test-containerized: dist/libnetwork-plugin-$(ARCH) bin/docker
+	docker run -t --rm --net=host \
 		-v $(CURDIR):/go/src/github.com/projectcalico/libnetwork-plugin \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(CURDIR)/docker:/usr/bin/docker	\
-		-e PLUGIN_LOCATION=$(CURDIR)/dist/libnetwork-plugin \
+		-v $(CURDIR)/bin/docker:/usr/bin/docker \
+		-e PLUGIN_LOCATION=$(CURDIR)/dist/libnetwork-plugin-$(ARCH) \
 		-e LOCAL_USER_ID=0 \
-		calico/go-build sh -c '\
+		-e ARCH=$(ARCH) \
+		-e BUSYBOX_IMAGE=$(BUSYBOX_IMAGE) \
+		$(GO_BUILD_CONTAINER) sh -c '\
 			cd  /go/src/github.com/projectcalico/libnetwork-plugin && \
 			make test'
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ SRC_FILES=$(shell find . -type f -name '*.go')
 LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 |  awk '{print $$7}')
 
 # Can choose different docker versions see list here - https://hub.docker.com/_/docker/
-DOCKER_VERSION?=dind
 HOST_CHECKOUT_DIR?=$(CURDIR)
 CONTAINER_NAME?=calico/libnetwork-plugin$(ARCHTAG)
 GO_BUILD_CONTAINER?=calico/go-build$(ARCHTAG):$(GO_BUILD_VER)
@@ -118,7 +117,7 @@ endif
 	@echo "docker push quay.io/calico/libnetwork-plugin$(ARCHTAG):latest"
 
 clean:
-	rm -rf dist *.tar vendor .go-pkg-cache
+	rm -rf dist bin *.tar vendor .go-pkg-cache
 
 run-plugin: run-etcd dist/libnetwork-plugin-$(ARCH)
 	-docker rm -f dind
@@ -146,7 +145,7 @@ test:
 bin/docker:
 	-docker rm -f $(DOCKER_BINARY_CONTAINER) 2>&1
 	mkdir -p ./bin
-	docker create --name $(DOCKER_BINARY_CONTAINER) docker:$(DOCKER_VERSION)
+	docker create --name $(DOCKER_BINARY_CONTAINER) $(DIND_IMAGE)
 	docker cp $(DOCKER_BINARY_CONTAINER):/usr/local/bin/docker ./bin/docker
 	docker rm -f $(DOCKER_BINARY_CONTAINER)
 

--- a/tests/custom_if_prefix/libnetwork_env_var_test.go
+++ b/tests/custom_if_prefix/libnetwork_env_var_test.go
@@ -3,6 +3,7 @@ package custom_if_prefix
 import (
 	"fmt"
 	"math/rand"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,7 +24,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))
 
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s busybox", name, name))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name, name)

--- a/tests/custom_wep_labelling/libnetwork_env_var_test.go
+++ b/tests/custom_wep_labelling/libnetwork_env_var_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"time"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,7 +24,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))
 
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s busybox", name, name))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name, name)
@@ -67,7 +68,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))
 
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s busybox", name, name))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name, name)

--- a/tests/default_environment/libnetwork_test.go
+++ b/tests/default_environment/libnetwork_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -137,7 +138,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 		It("creates a container on a network  and checks all assertions", func() {
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s busybox", name, name))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name, name)
@@ -182,7 +183,7 @@ var _ = Describe("Libnetwork Tests", func() {
 		It("creates a container with specific MAC", func() {
 			// Create a container that will just sit in the background
 			chosen_mac := "00:22:33:44:55:66"
-			DockerString(fmt.Sprintf("docker run --mac-address %s --net %s -tid --name %s busybox", chosen_mac, name, name))
+			DockerString(fmt.Sprintf("docker run --mac-address %s --net %s -tid --name %s %s", chosen_mac, name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name, name)
@@ -219,7 +220,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 		PIt("creates a container with specific link local address", func() { // https://github.com/docker/docker/issues/28606
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --link-local-ip 169.254.0.50 %s --net %s -tid --name %s busybox", name, name, name))
+			DockerString(fmt.Sprintf("docker run --link-local-ip 169.254.0.50 %s --net %s -tid --name %s %s", name, name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
@@ -234,7 +235,7 @@ var _ = Describe("Libnetwork Tests", func() {
 			DockerString(fmt.Sprintf("docker network create %s --subnet 192.169.0.0/16 -d calico --ipam-driver calico-ipam", name_subnet))
 			// Create a container that will just sit in the background
 			chosen_ip := "192.169.50.51"
-			DockerString(fmt.Sprintf("docker run --ip %s --net %s -tid --name %s busybox", chosen_ip, name_subnet, name_subnet))
+			DockerString(fmt.Sprintf("docker run --ip %s --net %s -tid --name %s %s", chosen_ip, name_subnet, name_subnet, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name_subnet, name_subnet)
@@ -271,7 +272,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 		It("creates a container with labels, but do not expect those in endpoint", func() {
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s busybox", name, name))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name, name)
@@ -304,7 +305,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 		It("creates a container on a network  and checks all assertions", func() {
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s busybox", name, name))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
 
 			// Gather information for assertions
 			docker_endpoint := GetDockerEndpoint(name, name)


### PR DESCRIPTION
Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
I had a couple of issues getting test-containerized running on ppc64le.  At this point there is no official docker:dind container for ppc64le so I had to build my own.  I expect this to be resolved in the near future.  Test-containerized needs a docker client to be available for the go-build container to use. It is obtained it from the docker:dind images docker.  This should provided the latest version.  However, this assumes that the go_build container has the required dependencies for docker or that docker is static. This may not always be the case for ppc64le. To resolve this I added bin/docker as a build target making test-containerized dependent on it.  On x86 nothing should change and the docker client will be obtained from the dind container.  However I now have the option of pre-populating bin/docker with a compatible docker client before starting the build.

test-containerized ran successfully on both x86 and ppc64le.