### PR TITLE
Enable ipv6 in the dind test container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ run-plugin: run-etcd dist/libnetwork-plugin
 		-v $(PLUGIN_LOCATION):/libnetwork-plugin \
 		docker:$(DOCKER_VERSION) --cluster-store=etcd://$(LOCAL_IP_ENV):2379
 	# View the logs by running 'docker exec dind cat plugin.log'
+	docker exec -tid --privileged dind sh -c 'sysctl -w net.ipv6.conf.default.disable_ipv6=0'
 	docker exec -tid --privileged dind sh -c '/libnetwork-plugin 2>>/plugin.log'
 	# To speak to this docker:
 	# export DOCKER_HOST=localhost:5375


### PR DESCRIPTION
Fix for issue #162.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
This patch avoids a Ci failure we have been seeing on Semaphore for some time.  See issue #162   

Here is the failure.
```
$ make test-containerized
<cut>
  • Failure [3.068 seconds]
Libnetwork Tests
/go/src/github.com/projectcalico/libnetwork-plugin/tests/default_environment/libnetwork_test.go:345
  docker run ipv6
  /go/src/github.com/projectcalico/libnetwork-plugin/tests/default_environment/libnetwork_test.go:342
    creates a container on a network  and checks all assertions [It]
    /go/src/github.com/projectcalico/libnetwork-plugin/tests/default_environment/libnetwork_test.go:341

    Expected
        <string>: 2001:db8:7f30:3859:b73a:3e8b:9882:1bc0 dev cali0  metric 256 
        fe80::/64 dev cali0  metric 256 
        unreachable default dev lo  metric -1  error -101
        ff00::/8 dev cali0  metric 256 
        unreachable default dev lo  metric -1  error -101
    to match regular expression
        <string>: default via fe80::.* dev cali0  metric 1024
```
This is a change to test code only.  My concern is if this is truly a test failure or a limitation of Calico.  See my comments in issue #162.  This patch re-enables ipv6 inside the dind container.  

I am ok calling this a test bug to get Ci working again.