### PR TITLE
Set veth MTU using CALICO_LIBNETWORK_VETH_MTU

### DIFF
--- a/utils/netns/netns.go
+++ b/utils/netns/netns.go
@@ -11,10 +11,11 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func CreateVeth(vethNameHost, vethNameNSTemp string) error {
+func CreateVeth(vethNameHost, vethNameNSTemp string, vethMTU uint16) error {
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: vethNameHost,
+			MTU: int(vethMTU),
 		},
 		PeerName: vethNameNSTemp,
 	}


### PR DESCRIPTION
## Description

Ref. https://github.com/projectcalico/calicoctl/issues/488

I've introduced an environment variable `CALICO_LIBNETWORK_VETH_MTU` to set the MTU of the veth pairs created by the Calico libnetwork plugin. As discussed in the issue above, this allows `FELIX_IPINIPMTU` to be controlled separately from the veth MTU.

Worth noting is that this extends the signature of `netns.CreateVeth`, and I'm not sure if there are any other packages that use this function.

This was tested manually, could not get the tests on master to run. I'll need some help/pointers on how to add this to the test suite.

Will this ever make it into 2.6, or should I add this to the 3.0 docs?

## Todos
- [ ] Tests
- [ ] Documentation
