### PR TITLE
Update for libcalico-go v1.7.2; rev go-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # considerably.
 .SUFFIXES:
 
+GO_BUILD_VER?=v0.9
+
 SRC_FILES=$(shell find . -type f -name '*.go')
 
 # These variables can be overridden by setting an environment variable.
@@ -11,7 +13,7 @@ LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 |  awk '{print $$7}')
 DOCKER_VERSION?=dind
 HOST_CHECKOUT_DIR?=$(CURDIR)
 CONTAINER_NAME?=calico/libnetwork-plugin
-CALICO_BUILD?=calico/go-build
+GO_BUILD_CONTAINER?=calico/go-build:$(GO_BUILD_VER)
 PLUGIN_LOCATION?=$(CURDIR)/dist/libnetwork-plugin
 DOCKER_BINARY_CONTAINER?=docker-binary-container
 
@@ -29,7 +31,7 @@ vendor: glide.yaml
 		-v $(CURDIR):/go/src/github.com/projectcalico/libnetwork-plugin:rw \
 		-v $(HOME)/.glide:/home/user/.glide:rw \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
-		$(CALICO_BUILD) /bin/sh -c ' \
+		$(GO_BUILD_CONTAINER) /bin/sh -c ' \
 			cd /go/src/github.com/projectcalico/libnetwork-plugin && \
 			glide install -strip-vendor' 
 
@@ -45,7 +47,7 @@ dist/libnetwork-plugin: vendor
 		-v $(CURDIR)/dist:/go/src/github.com/projectcalico/libnetwork-plugin/dist \
 		-v $(CURDIR)/.go-pkg-cache:/go/pkg/:rw \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
-		$(CALICO_BUILD) sh -c '\
+		$(GO_BUILD_CONTAINER) sh -c '\
 			cd /go/src/github.com/projectcalico/libnetwork-plugin && \
 			make build'
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,25 @@
-hash: f1b87069fa5857ab2fc2efc0847354e40357af64e9b84dea0daeae59884ad6c9
-updated: 2017-07-31T15:25:24.514237992-07:00
+hash: d7d49ac6b7387ddc5e626bdd471ef75314e33285ff86e45adb847ed61e40def8
+updated: 2017-11-21T16:05:33.286729077-08:00
 imports:
 - name: github.com/coreos/etcd
-  version: c31bec0f29facff13f7c3e3d948e55dd6689ed42
+  version: 17ae440991da3bdb2df4309936dd2074f66ec394
   subpackages:
   - client
   - pkg/pathutil
-  - pkg/srv
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
   - version
+- name: github.com/coreos/go-oidc
+  version: be73733bb8cc830d0205609b95d125215f8e9c70
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
 - name: github.com/coreos/go-semver
-  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
+  version: 568e959cd89871e61434c1143528d9162da89ef2
   subpackages:
   - semver
 - name: github.com/coreos/go-systemd
@@ -22,6 +29,13 @@ imports:
   - daemon
   - journal
   - util
+- name: github.com/coreos/pkg
+  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
+  subpackages:
+  - capnslog
+  - health
+  - httputil
+  - timeutil
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -32,7 +46,7 @@ imports:
   - digest
   - reference
 - name: github.com/docker/docker
-  version: 60ccb2265b0574d6c1c1090876a1d1ab32bed60e
+  version: f5ec1e2936dcbe7b5001c2b817188b095c700c27
   subpackages:
   - api/types
   - api/types/blkiodev
@@ -57,7 +71,7 @@ imports:
   - sockets
   - tlsconfig
 - name: github.com/docker/go-plugins-helpers
-  version: 96217206cc52dcc41d4ace9a9bef8c6111f2e5f9
+  version: bd8c600f0cdd76c7a57ff6aa86bd2b423868c688
   subpackages:
   - ipam
   - network
@@ -65,12 +79,12 @@ imports:
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/emicklei/go-restful
-  version: 09691a3b6378b740595c1002f40c34dd5f218a22
+  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
   subpackages:
   - log
   - swagger
 - name: github.com/ghodss/yaml
-  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -86,16 +100,23 @@ imports:
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/protobuf
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  subpackages:
+  - jsonpb
+  - proto
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+- name: github.com/jonboulle/clockwork
+  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
+  version: 91921eb4cf999321cdbeebdba5a03555800d493b
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -103,7 +124,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/Microsoft/go-winio
-  version: 7ff89941bcb93df2e962467fb073c6e997b13cf0
+  version: 78439966b38d69bf38227fbf57ac8a6fee70f69a
 - name: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
   subpackages:
@@ -141,7 +162,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
+  version: f15c970de5b76fac0b59abb32d62c17cc7bed265
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -151,7 +172,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 93f9e49214a678551648eb9c28ce57bc286a3169
+  version: 119c3c82c1c22337ceaffea0cdca5b127a139a1d
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -159,9 +180,10 @@ imports:
   - lib/backend/api
   - lib/backend/compat
   - lib/backend/etcd
+  - lib/backend/extensions
   - lib/backend/k8s
+  - lib/backend/k8s/custom
   - lib/backend/k8s/resources
-  - lib/backend/k8s/thirdparty
   - lib/backend/model
   - lib/client
   - lib/converter
@@ -181,7 +203,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
@@ -191,11 +213,11 @@ imports:
   subpackages:
   - codec
 - name: github.com/vishvananda/netlink
-  version: 8d7f7aad193e778023f06a843a26ffc9615ca840
+  version: c2a3de3b38bd00f07290c3c5e12b4dbc04ec8666
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 86bef332bfc3b59b7624a600bd53009ce91a9829
+  version: be1fbeda19366dea804f00efff2dd73a1642fdcc
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
@@ -203,7 +225,7 @@ imports:
   - blowfish
   - ssh/terminal
 - name: golang.org/x/net
-  version: c8c74377599bd978aee1cf3b9b63a8634051cec2
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
   - context/ctxhttp
@@ -215,8 +237,15 @@ imports:
   - idna
   - lex/httplex
   - proxy
+- name: golang.org/x/oauth2
+  version: 045497edb6234273d67dbc25da3f2ddbc4c4cacf
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
-  version: e48874b42435b4347fc52bdee0424a52abc974d7
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
   - windows
@@ -245,8 +274,27 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: google.golang.org/appengine
+  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
+- name: google.golang.org/cloud
+  version: 975617b05ea8a58727e6c1a06b6161ff4185a9f2
+  subpackages:
+  - compute/metadata
+  - internal
+  - internal/opts
+  - storage
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
+  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2
@@ -254,7 +302,7 @@ imports:
   subpackages:
   - patricia
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/apimachinery
   version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
   subpackages:
@@ -375,8 +423,12 @@ imports:
   - pkg/util/wait
   - pkg/version
   - pkg/watch
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
   - rest
   - rest/watch
+  - third_party/forked/golang/template
   - tools/auth
   - tools/cache
   - tools/clientcmd
@@ -390,4 +442,5 @@ imports:
   - util/flowcontrol
   - util/homedir
   - util/integer
+  - util/jsonpath
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,8 +1,19 @@
 package: github.com/projectcalico/libnetwork-plugin
 import:
+- package: github.com/projectcalico/libcalico-go
+  version: 119c3c82c1c22337ceaffea0cdca5b127a139a1d
+- package: github.com/coreos/etcd
+  version: 17ae440991da3bdb2df4309936dd2074f66ec394
+- package: github.com/ugorji/go
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  subpackages:
+  - codec
+- package: github.com/emicklei/go-restful                                                                                               
+  version: v1.2
 - package: github.com/sirupsen/logrus
+  version: ^0.10.0
 - package: github.com/docker/docker
-  version: v17.03.0-ce
+  version: v17.03.2-ce
   subpackages:
   - client
 - package: github.com/docker/go-plugins-helpers
@@ -10,18 +21,9 @@ import:
   - ipam
   - network
 - package: github.com/pkg/errors
-- package: github.com/projectcalico/libcalico-go
-  version: 93f9e49214a678551648eb9c28ce57bc286a3169
-  subpackages:
-  - lib/api
-  - lib/client
-  - lib/errors
-  - lib/net
 - package: github.com/vishvananda/netlink
+
 testImport:
-- package: github.com/coreos/etcd
-  subpackages:
-  - client
 - package: github.com/onsi/ginkgo
 - package: github.com/onsi/gomega
   subpackages:


### PR DESCRIPTION
## Description
Pin libcalico-go import to the hash associated with v1.7.2 branch. Pin go_build version to 0.9 for latest CVE fixes. Passes `test-containerized`.

## Todos
- [ ] Tests
- [ ] Documentation

