### PR TITLE
Pin Alpine to 3.6 and go-build to v0.8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.6
 MAINTAINER Tom Denham <tom@projectcalico.org>
 ADD dist/libnetwork-plugin /libnetwork-plugin
 ENTRYPOINT ["/libnetwork-plugin"]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 |  awk '{print $$7}')
 DOCKER_VERSION?=rc-dind
 HOST_CHECKOUT_DIR?=$(CURDIR)
 CONTAINER_NAME?=calico/libnetwork-plugin
-CALICO_BUILD?=calico/go-build
+CALICO_BUILD?=calico/go-build:v0.8
 PLUGIN_LOCATION?=$(CURDIR)/dist/libnetwork-plugin
 DOCKER_BINARY_CONTAINER?=docker-binary-container
 
@@ -54,7 +54,7 @@ build: $(SRC_FILES) vendor
 	CGO_ENABLED=0 go build -v -i -o dist/libnetwork-plugin -ldflags "-X main.VERSION=$(shell git describe --tags --dirty) -s -w" main.go
 
 $(CONTAINER_NAME): dist/libnetwork-plugin
-	docker build -t $(CONTAINER_NAME) .
+	docker build --pull -t $(CONTAINER_NAME) .
 
 # Perform static checks on the code. The golint checks are allowed to fail, the others must pass.
 .PHONY: static-checks

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 89217814ede547cfb86bfb4c536808aebcb7ba3feed24898f1643c12bf5e23be
-updated: 2016-12-13T16:28:16.406100592-08:00
+updated: 2017-11-21T14:58:35.948362422Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -29,6 +29,7 @@ imports:
   version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
   - activation
+  - daemon
   - journal
   - util
 - name: github.com/coreos/pkg
@@ -126,6 +127,41 @@ imports:
   - jwriter
 - name: github.com/Microsoft/go-winio
   version: 24a3e3d3fc7451805e09d11e11e95d9a0a4f205e
+- name: github.com/onsi/ginkgo
+  version: 00054c0bb96fc880d4e0be1b90937fad438c5290
+  subpackages:
+  - config
+  - internal/codelocation
+  - internal/containernode
+  - internal/failer
+  - internal/leafnodes
+  - internal/remote
+  - internal/spec
+  - internal/specrunner
+  - internal/suite
+  - internal/testingtproxy
+  - internal/writer
+  - reporters
+  - reporters/stenographer
+  - reporters/stenographer/support/go-colorable
+  - reporters/stenographer/support/go-isatty
+  - types
+- name: github.com/onsi/gomega
+  version: f1f0f388b31eca4e2cbe7a6dd8a3a1dfddda5b1c
+  subpackages:
+  - format
+  - gbytes
+  - gexec
+  - internal/assertion
+  - internal/asyncassertion
+  - internal/oraclematcher
+  - internal/testingtsupport
+  - matchers
+  - matchers/support/goraph/bipartitegraph
+  - matchers/support/goraph/edge
+  - matchers/support/goraph/node
+  - matchers/support/goraph/util
+  - types
 - name: github.com/opencontainers/runc
   version: 083933fb9092a3d65d682ba34a08676104c95462
   subpackages:
@@ -357,39 +393,4 @@ imports:
   - tools/clientcmd/api/v1
   - tools/metrics
   - transport
-testImports:
-- name: github.com/onsi/ginkgo
-  version: 00054c0bb96fc880d4e0be1b90937fad438c5290
-  subpackages:
-  - config
-  - internal/codelocation
-  - internal/containernode
-  - internal/failer
-  - internal/leafnodes
-  - internal/remote
-  - internal/spec
-  - internal/specrunner
-  - internal/suite
-  - internal/testingtproxy
-  - internal/writer
-  - reporters
-  - reporters/stenographer
-  - reporters/stenographer/support/go-colorable
-  - reporters/stenographer/support/go-isatty
-  - types
-- name: github.com/onsi/gomega
-  version: f1f0f388b31eca4e2cbe7a6dd8a3a1dfddda5b1c
-  subpackages:
-  - format
-  - gbytes
-  - gexec
-  - internal/assertion
-  - internal/asyncassertion
-  - internal/oraclematcher
-  - internal/testingtsupport
-  - matchers
-  - matchers/support/goraph/bipartitegraph
-  - matchers/support/goraph/edge
-  - matchers/support/goraph/node
-  - matchers/support/goraph/util
-  - types
+testImports: []

--- a/tests/custom_if_prefix/libnetwork_env_var_test.go
+++ b/tests/custom_if_prefix/libnetwork_env_var_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Running plugin with custom ENV", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev test0 \n169.254.1.1 dev test0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev test0 \n169.254.1.1 dev test0 scope link"))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))

--- a/tests/default_environment/libnetwork_test.go
+++ b/tests/default_environment/libnetwork_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
@@ -204,7 +204,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
@@ -255,7 +255,7 @@ var _ = Describe("Libnetwork Tests", func() {
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name_subnet))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0"))
+			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
 
 			// Delete container and network
 			DockerString(fmt.Sprintf("docker rm -f %s", name_subnet))


### PR DESCRIPTION
## Description

Ensure Alpine gets pulled when building image to pick up security fixes.

Pin alpine and go-build for repeatability.  go-build v0.8 uses Go 1.8.5, which is appropriate for 2.6.x.

## Todos
- [ ] Tests
- [ ] Documentation

