### PR TITLE
change cap. RequiresMACAddress to true

### DIFF
--- a/driver/ipam_driver.go
+++ b/driver/ipam_driver.go
@@ -32,7 +32,7 @@ func NewIpamDriver(client *datastoreClient.Client) ipam.Ipam {
 }
 
 func (i IpamDriver) GetCapabilities() (*ipam.CapabilitiesResponse, error) {
-	resp := ipam.CapabilitiesResponse{}
+	resp := ipam.CapabilitiesResponse{RequiresMACAddress: true}
 	logutils.JSONMessage("GetCapabilities response", resp)
 	return &resp, nil
 }


### PR DESCRIPTION
Related to https://github.com/projectcalico/calicoctl/issues/1817
Libnetwork plugin is not functional since docker 18.03

## Description
With RequiresMACAddress set to false docker ignores mac change. 
