### PR TITLE
IPAM: allocate when docker network has subnet

### DIFF
--- a/driver/ipam_driver.go
+++ b/driver/ipam_driver.go
@@ -179,9 +179,11 @@ func (i IpamDriver) RequestAddress(request *ipam.RequestAddressRequest) (*ipam.R
 			version = ipNet.Version()
 			if version == 4 {
 				poolV4 = []caliconet.IPNet{caliconet.IPNet{IPNet: pool.Metadata.CIDR.IPNet}}
+				numIPv4 = 1
 				log.Debugln("Using specific pool ", poolV4)
 			} else if version == 6 {
 				poolV6 = []caliconet.IPNet{caliconet.IPNet{IPNet: pool.Metadata.CIDR.IPNet}}
+				numIPv6 = 1
 				log.Debugln("Using specific pool ", poolV6)
 			}
 		}


### PR DESCRIPTION
## Description

libnetwork-plugin v1.1.1 (as part of calico v2.6.3) introduced a bug
where IPAM broken if a docker network was created with --subnet.

The encountered error was:

> docker: Error response from daemon: IpamDriver.RequestAddress:
Unexpected number of assigned IP addresses. A single address should be
assigned. Got []

The IPAM client's AutoAssign() method ignores AutoAssignArgs.IPv{4,6}Pools
and therefore does not appear to allocate any addresses unless numIPv4/6
is non-zero.

Fixes https://github.com/projectcalico/calico/issues/1512

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
IPAM driver should still allocated addresses to if a docker network was created with an explicit --subnet.
```
