### PR TITLE
supoort calico v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ cover
 calicoctl
 *.tar
 *.created
+libnetwork-plugin
 .go-pkg-cache/

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifeq ($(ARCH),x86_64)
 	override ARCH=amd64
 endif
 
-GO_BUILD_VER ?= v0.15
+GO_BUILD_VER ?= v0.16
 # for building, we use the go-build image for the *host* architecture, even if the target is different
 # the one for the host should contain all the necessary cross-compilation tools.
 # cross-compilation is only supported on amd64.
@@ -46,7 +46,7 @@ endif
 BUSYBOX_IMAGE_VERSION ?= latest
 BUSYBOX_IMAGE ?= $(BUILDARCH)/busybox:$(BUSYBOX_IMAGE_VERSION)
 
-DIND_IMAGE_VERSION ?= 17.12.0-dind
+DIND_IMAGE_VERSION ?= 18.05.0-dind
 DIND_IMAGE ?= $(BUILDARCH)/docker:$(DIND_IMAGE_VERSION)
 
 # Disable make's implicit rules, which are not useful for golang, and slow down the build

--- a/glide.lock
+++ b/glide.lock
@@ -1,74 +1,77 @@
-hash: 3da22fbbf92cc2be6d9994f73965a99230305725d9a1c27087cf382e38d88b58
-updated: 2017-12-14T14:58:20.689330047-08:00
+hash: eb9e4c379ebcbbd831d0a2ddfef1d67649da854f86215045261963be6d66e4f8
+updated: 2018-06-21T09:55:01.317369+08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
   subpackages:
   - compute/metadata
   - internal
-- name: github.com/coreos/etcd
-  version: 17ae440991da3bdb2df4309936dd2074f66ec394
+- name: github.com/Azure/go-autorest
+  version: 58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d
   subpackages:
+  - autorest
+  - autorest/adal
+  - autorest/azure
+  - autorest/date
+- name: github.com/codegangsta/cli
+  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
+- name: github.com/coreos/etcd
+  version: 33245c6b5b49130ca99280408fadfab01aac0e48
+  subpackages:
+  - auth/authpb
   - client
+  - clientv3
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/etcdserverpb
+  - mvcc/mvccpb
   - pkg/pathutil
+  - pkg/srv
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
   - version
-- name: github.com/coreos/go-oidc
-  version: be73733bb8cc830d0205609b95d125215f8e9c70
-  subpackages:
-  - http
-  - jose
-  - key
-  - oauth2
-  - oidc
 - name: github.com/coreos/go-semver
-  version: 568e959cd89871e61434c1143528d9162da89ef2
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
   - semver
 - name: github.com/coreos/go-systemd
-  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
+  version: d2196463941895ee908e13531a23a39feb9e1243
   subpackages:
   - activation
   - daemon
   - journal
   - util
-- name: github.com/coreos/pkg
-  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
-  subpackages:
-  - capnslog
-  - health
-  - httputil
-  - timeutil
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
   - spew
+- name: github.com/dgrijalva/jwt-go
+  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/docker/distribution
   version: f4118485915abb8b163442717326597908eee6aa
   subpackages:
   - digestset
   - reference
 - name: github.com/docker/docker
-  version: f5ec1e2936dcbe7b5001c2b817188b095c700c27
+  version: e2593239d949eee454935daea7a5fe025477322f
   subpackages:
+  - api
   - api/types
   - api/types/blkiodev
   - api/types/container
   - api/types/events
   - api/types/filters
+  - api/types/image
   - api/types/mount
   - api/types/network
-  - api/types/reference
   - api/types/registry
   - api/types/strslice
   - api/types/swarm
+  - api/types/swarm/runtime
   - api/types/time
   - api/types/versions
   - api/types/volume
   - client
-  - pkg/tlsconfig
 - name: github.com/docker/go-connections
   version: 3ede32e2033de7505e6500d6c868c2b9ed9f169d
   subpackages:
@@ -82,12 +85,13 @@ imports:
   - network
   - sdk
 - name: github.com/docker/go-units
-  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+  version: 47565b4f722fb6ceae66b95f853feed578a4a51c
 - name: github.com/emicklei/go-restful
-  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
+  version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
   - log
-  - swagger
+- name: github.com/emicklei/go-restful-swagger12
+  version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
@@ -99,29 +103,59 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
-  version: 909568be09de550ed094403c2bf8a261b5bb730a
+  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
+  - gogoproto
   - proto
+  - protoc-gen-gogo/descriptor
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
   version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
-  - jsonpb
   - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
+- name: github.com/google/btree
+  version: 925471ac9e2131377a91e1595defec898166fe49
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+- name: github.com/googleapis/gnostic
+  version: 68f4ded48ba9414dab2ae69b3f0d69971da73aa5
+  subpackages:
+  - OpenAPIv2
+  - compiler
+  - extensions
+- name: github.com/gophercloud/gophercloud
+  version: 2bf16b94fdd9b01557c4d076e567fe5cbbe5a961
+  subpackages:
+  - openstack
+  - openstack/identity/v2/tenants
+  - openstack/identity/v2/tokens
+  - openstack/identity/v3/tokens
+  - openstack/utils
+  - pagination
+- name: github.com/gregjones/httpcache
+  version: 787624de3eb7bd915c329cba748687a3b22666a6
+  subpackages:
+  - diskcache
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
 - name: github.com/howeyc/gopass
-  version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
+  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
-- name: github.com/jonboulle/clockwork
-  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+- name: github.com/json-iterator/go
+  version: 36b14963da70d11297d313183d7e6388c8510e1e
 - name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+  version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/kelseyhightower/envconfig
-  version: 462fda1f11d8cad3660e52737b8beefd27acfb3f
+  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -131,7 +165,7 @@ imports:
 - name: github.com/Microsoft/go-winio
   version: 78439966b38d69bf38227fbf57ac8a6fee70f69a
 - name: github.com/onsi/ginkgo
-  version: bc14b6691e7a788e12a21121abdaff1ccdcef9e9
+  version: fa5fabab2a1bfbd924faf4c067d07ae414e2aedf
   subpackages:
   - config
   - internal/codelocation
@@ -168,6 +202,15 @@ imports:
   - types
 - name: github.com/opencontainers/go-digest
   version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
+- name: github.com/opencontainers/image-spec
+  version: e562b04403929d582d449ae5386ff79dd7961a11
+  subpackages:
+  - specs-go
+  - specs-go/v1
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/peterbourgon/diskv
+  version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/pkg/errors
   version: 8842a6e0cc595d1cc9d931f6c875883967280e32
 - name: github.com/projectcalico/go-json
@@ -179,44 +222,48 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: d5ff4aa493340f0239d9b9e557e11603b3f84532
+  version: efdf8fede805a0669c5233bace020ae57f2e6c5b
   subpackages:
-  - lib/api
-  - lib/api/unversioned
+  - lib/apiconfig
+  - lib/apis/v1
+  - lib/apis/v1/unversioned
+  - lib/apis/v3
   - lib/backend
   - lib/backend/api
-  - lib/backend/compat
-  - lib/backend/etcd
-  - lib/backend/extensions
+  - lib/backend/etcdv3
   - lib/backend/k8s
-  - lib/backend/k8s/custom
+  - lib/backend/k8s/conversion
   - lib/backend/k8s/resources
   - lib/backend/model
-  - lib/client
-  - lib/converter
+  - lib/clientv3
   - lib/errors
   - lib/hash
-  - lib/hwm
+  - lib/ipam
   - lib/ipip
+  - lib/names
+  - lib/namespace
   - lib/net
   - lib/numorstring
+  - lib/options
   - lib/scope
   - lib/selector
   - lib/selector/parser
   - lib/selector/tokenizer
-  - lib/validator
+  - lib/set
+  - lib/validator/v3
+  - lib/watch
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  version: bdcc60b419d136a85cdf2e7cbcac34b3f1cd6e57
   subpackages:
   - codec
 - name: github.com/vishvananda/netlink
@@ -228,11 +275,9 @@ imports:
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
-  - bcrypt
-  - blowfish
   - ssh/terminal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - context
   - context/ctxhttp
@@ -242,22 +287,24 @@ imports:
   - http2
   - http2/hpack
   - idna
+  - internal/timeseries
   - lex/httplex
   - proxy
+  - trace
 - name: golang.org/x/oauth2
-  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
+  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
   subpackages:
   - google
   - internal
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 1d2aa6dbdea45adaaebb9905d0666e4537563829
+  version: ebfc5b4631820b793c9010c87fd8fef0f39eb082
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
+  version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
   - cases
   - encoding
@@ -293,32 +340,80 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e
+  subpackages:
+  - balancer
+  - codes
+  - connectivity
+  - credentials
+  - grpclb/grpc_lb_v1/messages
+  - grpclog
+  - health
+  - health/grpc_health_v1
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - resolver
+  - stats
+  - status
+  - tap
+  - transport
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
+  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
-- name: gopkg.in/tchap/go-patricia.v2
-  version: 666120de432aea38ab06bd5c818f04f4129882c9
-  subpackages:
-  - patricia
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
-- name: k8s.io/apimachinery
-  version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
+- name: k8s.io/api
+  version: a315a049e7a93e5455f7fefce1ba136d85054687
   subpackages:
+  - admissionregistration/v1alpha1
+  - apps/v1beta1
+  - apps/v1beta2
+  - authentication/v1
+  - authentication/v1beta1
+  - authorization/v1
+  - authorization/v1beta1
+  - autoscaling/v1
+  - autoscaling/v2beta1
+  - batch/v1
+  - batch/v1beta1
+  - batch/v2alpha1
+  - certificates/v1beta1
+  - core/v1
+  - extensions/v1beta1
+  - networking/v1
+  - policy/v1beta1
+  - rbac/v1
+  - rbac/v1alpha1
+  - rbac/v1beta1
+  - scheduling/v1alpha1
+  - settings/v1alpha1
+  - storage/v1
+  - storage/v1beta1
+- name: k8s.io/apimachinery
+  version: 40eaf68ee1889b1da1c528b1a075ecfe94e66837
+  subpackages:
+  - pkg/api/equality
   - pkg/api/errors
   - pkg/api/meta
   - pkg/api/resource
-  - pkg/apimachinery
-  - pkg/apimachinery/announced
-  - pkg/apimachinery/registered
+  - pkg/apis/meta/internalversion
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1alpha1
   - pkg/conversion
   - pkg/conversion/queryparams
+  - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
-  - pkg/openapi
   - pkg/runtime
   - pkg/runtime/schema
   - pkg/runtime/serializer
@@ -329,15 +424,17 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
+  - pkg/util/cache
+  - pkg/util/clock
   - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
   - pkg/util/net
-  - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
@@ -346,86 +443,41 @@ imports:
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
+  version: 82aa063804cf055e16e8911250f888bc216e8b61
   subpackages:
   - discovery
   - kubernetes
   - kubernetes/scheme
+  - kubernetes/typed/admissionregistration/v1alpha1
   - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/apps/v1beta2
   - kubernetes/typed/authentication/v1
   - kubernetes/typed/authentication/v1beta1
   - kubernetes/typed/authorization/v1
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/autoscaling/v1
-  - kubernetes/typed/autoscaling/v2alpha1
+  - kubernetes/typed/autoscaling/v2beta1
   - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v1beta1
   - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/certificates/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/networking/v1
   - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/rbac/v1
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/scheduling/v1alpha1
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
-  - pkg/api
-  - pkg/api/errors
-  - pkg/api/install
-  - pkg/api/meta
-  - pkg/api/unversioned
-  - pkg/api/v1
-  - pkg/apis/apps
-  - pkg/apis/apps/install
-  - pkg/apis/apps/v1beta1
-  - pkg/apis/authentication
-  - pkg/apis/authentication/install
-  - pkg/apis/authentication/v1
-  - pkg/apis/authentication/v1beta1
-  - pkg/apis/authorization
-  - pkg/apis/authorization/install
-  - pkg/apis/authorization/v1
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/install
-  - pkg/apis/autoscaling/v1
-  - pkg/apis/autoscaling/v2alpha1
-  - pkg/apis/batch
-  - pkg/apis/batch/install
-  - pkg/apis/batch/v1
-  - pkg/apis/batch/v2alpha1
-  - pkg/apis/certificates
-  - pkg/apis/certificates/install
-  - pkg/apis/certificates/v1beta1
-  - pkg/apis/extensions
-  - pkg/apis/extensions/install
-  - pkg/apis/extensions/v1beta1
-  - pkg/apis/policy
-  - pkg/apis/policy/install
-  - pkg/apis/policy/v1beta1
-  - pkg/apis/rbac
-  - pkg/apis/rbac/install
-  - pkg/apis/rbac/v1alpha1
-  - pkg/apis/rbac/v1beta1
-  - pkg/apis/settings
-  - pkg/apis/settings/install
-  - pkg/apis/settings/v1alpha1
-  - pkg/apis/storage
-  - pkg/apis/storage/install
-  - pkg/apis/storage/v1
-  - pkg/apis/storage/v1beta1
-  - pkg/fields
-  - pkg/runtime
-  - pkg/runtime/schema
-  - pkg/runtime/serializer
-  - pkg/util
-  - pkg/util/parsers
-  - pkg/util/wait
   - pkg/version
-  - pkg/watch
   - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/azure
   - plugin/pkg/client/auth/gcp
   - plugin/pkg/client/auth/oidc
+  - plugin/pkg/client/auth/openstack
   - rest
   - rest/watch
   - third_party/forked/golang/template
@@ -436,11 +488,16 @@ imports:
   - tools/clientcmd/api/latest
   - tools/clientcmd/api/v1
   - tools/metrics
+  - tools/pager
+  - tools/reference
   - transport
   - util/cert
-  - util/clock
   - util/flowcontrol
   - util/homedir
   - util/integer
   - util/jsonpath
+- name: k8s.io/kube-openapi
+  version: 0c329704159e3b051aafac400b15baacf2a94a04
+  subpackages:
+  - pkg/common
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,29 +1,17 @@
 package: github.com/projectcalico/libnetwork-plugin
 import:
-- package: github.com/projectcalico/libcalico-go
-  version: v1.7.x-series
-- package: github.com/coreos/etcd
-  version: 17ae440991da3bdb2df4309936dd2074f66ec394
-- package: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
-  subpackages:
-  - codec
-- package: github.com/emicklei/go-restful                                                                                               
-  version: v1.2
 - package: github.com/sirupsen/logrus
-  version: ^0.10.0
-- package: github.com/docker/docker
-  version: v17.03.2-ce
-  subpackages:
-  - client
+  version: ^1.0.5
+- package: github.com/codegangsta/cli
+  version: ^1.20.0
 - package: github.com/docker/go-plugins-helpers
   subpackages:
   - ipam
   - network
-- package: github.com/pkg/errors
-- package: github.com/vishvananda/netlink
-
-testImport:
+- package: github.com/projectcalico/libcalico-go
+  version: master
+- package: github.com/docker/docker
+  version: master
 - package: github.com/onsi/ginkgo
 - package: github.com/onsi/gomega
   subpackages:

--- a/main.go
+++ b/main.go
@@ -5,15 +5,14 @@ import (
 
 	"github.com/docker/go-plugins-helpers/ipam"
 	"github.com/docker/go-plugins-helpers/network"
-	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libnetwork-plugin/driver"
 	log "github.com/sirupsen/logrus"
 
 	"flag"
 
 	"fmt"
-
-	datastoreClient "github.com/projectcalico/libcalico-go/lib/client"
 )
 
 const (
@@ -22,8 +21,8 @@ const (
 )
 
 var (
-	config *api.CalicoAPIConfig
-	client *datastoreClient.Client
+	config *apiconfig.CalicoAPIConfig
+	client clientv3.Interface
 )
 
 func init() {
@@ -34,10 +33,10 @@ func init() {
 func initializeClient() {
 	var err error
 
-	if config, err = datastoreClient.LoadClientConfig(""); err != nil {
+	if config, err = apiconfig.LoadClientConfig(""); err != nil {
 		panic(err)
 	}
-	if client, err = datastoreClient.New(*config); err != nil {
+	if client, err = clientv3.New(*config); err != nil {
 		panic(err)
 	}
 

--- a/tests/custom_wep_labelling/libnetwork_env_var_test.go
+++ b/tests/custom_wep_labelling/libnetwork_env_var_test.go
@@ -1,13 +1,15 @@
 package custom_wep_labelling
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
-	"time"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	mathutils "github.com/projectcalico/libnetwork-plugin/utils/math"
 	. "github.com/projectcalico/libnetwork-plugin/utils/test"
 )
@@ -17,39 +19,50 @@ var _ = Describe("Running plugin with custom ENV", func() {
 		It("creates a container on a network with WEP labelling enabled", func() {
 			RunPlugin("-e CALICO_LIBNETWORK_LABEL_ENDPOINTS=true")
 
+			pool := "test"
+			subnet := "192.169.1.0/24"
 			// Since running the plugin starts etcd, the pool needs to be created after.
-			CreatePool("192.169.1.0/24", false)
+			CreatePool(pool, subnet)
 
 			name := fmt.Sprintf("run%d", rand.Uint32())
-			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))
+			nid := DockerString(fmt.Sprintf("docker network create -d calico --ipam-driver calico-ipam --subnet %s %s ", subnet, pool))
+			UpdatePool(pool, subnet, nid)
 
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name, name)
-			ip := docker_endpoint.IPAddress
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
+			dockerEndpoint := GetDockerEndpoint(name, pool)
+			endpointID := dockerEndpoint.EndpointID
+			vethName := "cali" + endpointID[:mathutils.MinInt(11, len(endpointID))]
 
 			// Sleep to allow the plugin to query the started container and update the WEP
 			// Alternative: query etcd until we hit jackpot or timeout
 			time.Sleep(time.Second)
 
 			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":["%s"],"ipv4_nets":["%s/32"],"ipv6_nets":[],"labels":{"baz":"quux","foo": "bar"}}`,
-				interface_name, mac, name, ip)))
+			key := fmt.Sprintf("/calico/resources/v3/projectcalico.org/workloadendpoints/libnetwork/test-libnetwork-libnetwork-%s", endpointID)
+			endpointJSON := GetEtcd(key)
+			wep := api.NewWorkloadEndpoint()
+			json.Unmarshal(endpointJSON, &wep)
+			Expect(wep.Spec.InterfaceName).Should(Equal(vethName))
+			v, ok := wep.ObjectMeta.Labels["foo"]
+			Expect(ok).Should(Equal(true))
+			Expect(v).Should(Equal("bar"))
+			v, ok = wep.ObjectMeta.Labels["baz"]
+			Expect(ok).Should(Equal(true))
+			Expect(v).Should(Equal("quux"))
+			_, ok = wep.ObjectMeta.Labels["not"]
+			Expect(ok).Should(Equal(false))
 
 			// Check profile
-			tags := GetEtcdString(fmt.Sprintf("/calico/v1/policy/profile/%s/tags", name))
-			labels := GetEtcdString(fmt.Sprintf("/calico/v1/policy/profile/%s/labels", name))
-			rules := GetEtcdString(fmt.Sprintf("/calico/v1/policy/profile/%s/rules", name))
-			Expect(tags).Should(MatchJSON(fmt.Sprintf(`["%s"]`, name)))
-			Expect(labels).Should(MatchJSON("{}"))
-			Expect(rules).Should(MatchJSON(fmt.Sprintf(`{"inbound_rules": [{"action": "allow","src_tag": "%s"}],"outbound_rules":[{"action": "allow"}]}`, name)))
+			profile := api.NewProfile()
+			json.Unmarshal(GetEtcd(fmt.Sprintf("/calico/resources/v3/projectcalico.org/profiles/%s", pool)), &profile)
+			Expect(profile.Name).Should(Equal(pool))
+			Expect(len(profile.Labels)).Should(Equal(0))
+			//tags deprecated
+			Expect(profile.Spec.Ingress[0].Action).Should(Equal(api.Allow))
+			Expect(profile.Spec.Egress[0].Action).Should(Equal(api.Allow))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
@@ -61,35 +74,49 @@ var _ = Describe("Running plugin with custom ENV", func() {
 			// Run the plugin with custom IFPREFIX
 			RunPlugin("-e CALICO_LIBNETWORK_LABEL_ENDPOINTS=true -e CALICO_LIBNETWORK_CREATE_PROFILES=false")
 
+			pool := "test2"
+			subnet := "192.169.2.0/24"
 			// Since running the plugin starts etcd, the pool needs to be created after.
-			CreatePool("192.169.2.0/24", true)
+			CreatePool(pool, subnet)
 
 			name := fmt.Sprintf("run%d", rand.Uint32())
-			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))
+			nid := DockerString(fmt.Sprintf("docker network create -d calico --ipam-driver calico-ipam --subnet %s %s ", subnet, pool))
+			UpdatePool(pool, subnet, nid)
 
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name, name)
-			ip := docker_endpoint.IPAddress
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
+			dockerEndpoint := GetDockerEndpoint(name, pool)
+			endpointID := dockerEndpoint.EndpointID
+			vethName := "cali" + endpointID[:mathutils.MinInt(11, len(endpointID))]
 
 			// Sleep to allow the plugin to query the started container and update the WEP
 			// Alternative: query etcd until we hit jackpot or timeout
 			time.Sleep(time.Second)
 
 			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":null,"ipv4_nets":["%s/32"],"ipv6_nets":[],"labels":{"baz":"quux","foo": "bar"}}`,
-				interface_name, mac, ip)))
+			key := fmt.Sprintf("/calico/resources/v3/projectcalico.org/workloadendpoints/libnetwork/test-libnetwork-libnetwork-%s", endpointID)
+			endpointJSON := GetEtcd(key)
+			wep := api.NewWorkloadEndpoint()
+			json.Unmarshal(endpointJSON, &wep)
+			Expect(wep.Spec.InterfaceName).Should(Equal(vethName))
+			v, ok := wep.ObjectMeta.Labels["foo"]
+			Expect(ok).Should(Equal(true))
+			Expect(v).Should(Equal("bar"))
+			v, ok = wep.ObjectMeta.Labels["baz"]
+			Expect(ok).Should(Equal(true))
+			Expect(v).Should(Equal("quux"))
+			_, ok = wep.ObjectMeta.Labels["not"]
+			Expect(ok).Should(Equal(false))
 
+			// Chech profile not created
+			notExists := GetNotExists(fmt.Sprintf("/calico/resources/v3/projectcalico.org/profiles/%s", pool))
+			Expect(notExists).Should(BeTrue())
+
+			// Check that the endpoint is created in etcd
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
 		})
 	})
-
 })

--- a/tests/default_environment/libnetwork_test.go
+++ b/tests/default_environment/libnetwork_test.go
@@ -1,15 +1,18 @@
 package default_environment
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
-	"regexp"
 	"os"
+	"regexp"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	mathutils "github.com/projectcalico/libnetwork-plugin/utils/math"
 	. "github.com/projectcalico/libnetwork-plugin/utils/test"
 )
@@ -17,8 +20,8 @@ import (
 var _ = Describe("Libnetwork Tests", func() {
 	BeforeEach(func() {
 		WipeEtcd()
-		CreatePool("192.169.0.0/16", false)
-		CreatePool("2001:db8::/32", true)
+		CreatePool("poolv4", "192.169.0.0/16")
+		CreatePool("poolv6", "2001:db8::/32")
 	})
 
 	// Run the plugin just once for all tests in this file.
@@ -128,99 +131,102 @@ var _ = Describe("Libnetwork Tests", func() {
 	//    --ip and --ip6
 	Describe("docker run", func() {
 		var name string
+		var pool string
+
 		BeforeEach(func() {
 			name = fmt.Sprintf("run%d", rand.Uint32())
-			DockerString(fmt.Sprintf("docker network create %s -d calico --ipam-driver calico-ipam", name))
-		})
-		AfterEach(func() {
-			DockerString(fmt.Sprintf("docker network rm %s", name))
+			pool = fmt.Sprintf("testp%d", rand.Uint32())
+			subnet := "192.170.0.0/16"
+			CreatePool(pool, subnet)
+			nid := DockerString(fmt.Sprintf("docker network create --driver calico --ipam-driver calico-ipam --subnet %s %s ", subnet, pool))
+			UpdatePool(pool, subnet, nid)
 		})
 
-		It("creates a container on a network  and checks all assertions", func() {
+		AfterEach(func() {
+			DockerString(fmt.Sprintf("docker rm -f %s", name))
+			DockerString(fmt.Sprintf("docker network rm %s", pool))
+		})
+
+		It("creates a container on a network and checks all assertions", func() {
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name, name)
-			ip := docker_endpoint.IPAddress
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
-
-			// Make sure that the MAC we got from docker matches the fixed mac that we use
-			Expect(mac).Should(Equal("ee:ee:ee:ee:ee:ee"))
+			dockerEndpoint := GetDockerEndpoint(name, pool)
+			ip := dockerEndpoint.IPAddress
+			mac := dockerEndpoint.MacAddress
+			endpointID := dockerEndpoint.EndpointID
+			vethName := "cali" + endpointID[:mathutils.MinInt(11, len(endpointID))]
 
 			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":["%s"],"ipv4_nets":["%s/32"],"ipv6_nets":[]}`,
-				interface_name, mac, name, ip)))
+			key := fmt.Sprintf("/calico/resources/v3/projectcalico.org/workloadendpoints/libnetwork/test-libnetwork-libnetwork-%s", endpointID)
+			endpointJSON := GetEtcd(key)
+			wep := api.NewWorkloadEndpoint()
+			json.Unmarshal(endpointJSON, &wep)
+			Expect(wep.Spec.InterfaceName).Should(Equal(vethName))
 
 			// Check profile
-			tags := GetEtcdString(fmt.Sprintf("/calico/v1/policy/profile/%s/tags", name))
-			labels := GetEtcdString(fmt.Sprintf("/calico/v1/policy/profile/%s/labels", name))
-			rules := GetEtcdString(fmt.Sprintf("/calico/v1/policy/profile/%s/rules", name))
-			Expect(tags).Should(MatchJSON(fmt.Sprintf(`["%s"]`, name)))
-			Expect(labels).Should(MatchJSON("{}"))
-			Expect(rules).Should(MatchJSON(fmt.Sprintf(`{"inbound_rules": [{"action": "allow","src_tag": "%s"}],"outbound_rules":[{"action": "allow"}]}`, name)))
+			profile := api.NewProfile()
+			json.Unmarshal(GetEtcd(fmt.Sprintf("/calico/resources/v3/projectcalico.org/profiles/%s", pool)), &profile)
+			Expect(profile.Name).Should(Equal(pool))
+			Expect(len(profile.Labels)).Should(Equal(0))
+			//tags deprecated
+			Expect(profile.Spec.Ingress[0].Action).Should(Equal(api.Allow))
+			Expect(profile.Spec.Egress[0].Action).Should(Equal(api.Allow))
 
 			// Check the interface exists on the Host - it has an autoassigned
 			// mac and ip, so don't check anything!
-			DockerString(fmt.Sprintf("ip addr show %s", interface_name))
+			DockerString(fmt.Sprintf("ip addr show %s", vethName))
 
 			// Make sure the interface in the container exists and has the  assigned ip and mac
-			container_interface_string := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name))
-			Expect(container_interface_string).Should(ContainSubstring(ip))
-			Expect(container_interface_string).Should(ContainSubstring(mac))
+			containerNICString := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name))
+			Expect(containerNICString).Should(ContainSubstring(ip))
+			Expect(containerNICString).Should(ContainSubstring(mac))
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
 			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
-
-			// Delete container
-			DockerString(fmt.Sprintf("docker rm -f %s", name))
 		})
+
 		It("creates a container with specific MAC", func() {
 			// Create a container that will just sit in the background
 			chosen_mac := "00:22:33:44:55:66"
-			DockerString(fmt.Sprintf("docker run --mac-address %s --net %s -tid --name %s %s", chosen_mac, name, name, os.Getenv("BUSYBOX_IMAGE") ))
+			DockerString(fmt.Sprintf("docker run --mac-address %s --net %s -tid --name %s %s", chosen_mac, pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name, name)
-			ip := docker_endpoint.IPAddress
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
+			dockerEndpoint := GetDockerEndpoint(name, pool)
+			ip := dockerEndpoint.IPAddress
+			mac := dockerEndpoint.MacAddress
+			endpointID := dockerEndpoint.EndpointID
+			vethName := "cali" + endpointID[:mathutils.MinInt(11, len(endpointID))]
 
 			// Make sure the discovered MAC is what we asked for
 			Expect(mac).Should(Equal(chosen_mac))
 
 			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":["%s"],"ipv4_nets":["%s/32"],"ipv6_nets":[]}`,
-				interface_name, mac, name, ip)))
+			key := fmt.Sprintf("/calico/resources/v3/projectcalico.org/workloadendpoints/libnetwork/test-libnetwork-libnetwork-%s", endpointID)
+			endpointJSON := GetEtcd(key)
+			wep := api.NewWorkloadEndpoint()
+			json.Unmarshal(endpointJSON, &wep)
+			Expect(wep.Spec.InterfaceName).Should(Equal(vethName))
 
 			// Check the interface exists on the Host - it has an autoassigned
 			// mac and ip, so don't check anything!
-			DockerString(fmt.Sprintf("ip addr show %s", interface_name))
+			DockerString(fmt.Sprintf("ip addr show %s", vethName))
 
 			// Make sure the interface in the container exists and has the  assigned ip and mac
-			container_interface_string := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name))
-			Expect(container_interface_string).Should(ContainSubstring(ip))
-			Expect(container_interface_string).Should(ContainSubstring(mac))
+			containerNICString := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name))
+			Expect(containerNICString).Should(ContainSubstring(ip))
+			Expect(containerNICString).Should(ContainSubstring(mac))
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
 			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
-
-			// Delete container
-			DockerString(fmt.Sprintf("docker rm -f %s", name))
 		})
 
 		PIt("creates a container with specific link local address", func() { // https://github.com/docker/docker/issues/28606
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --link-local-ip 169.254.0.50 %s --net %s -tid --name %s %s", name, name, name, os.Getenv("BUSYBOX_IMAGE") ))
+			DockerString(fmt.Sprintf("docker run --link-local-ip 169.254.0.50 --net %s -tid --name %s %s", pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Delete container
 			DockerString(fmt.Sprintf("docker rm -f %s", name))
@@ -230,144 +236,113 @@ var _ = Describe("Libnetwork Tests", func() {
 		// TODO allocate specific IPs from specific pools - see test cases in https://github.com/projectcalico/libnetwork-plugin/pull/101/files/c8c0386a41a569fbef33fae545ad97fa061470ed#diff-3bca4eb4bf01d8f50e7babc5c90236cc
 		// TODO auto alloc IPs from a specific pool - see https://github.com/projectcalico/libnetwork-plugin/pull/101/files/c8c0386a41a569fbef33fae545ad97fa061470ed#diff-2667baf0dbc5ac5027aa29690f306535
 		It("creates a container with specific IP", func() {
-			// Create a network with a chosen subnet as this is required to choose an IP
-			name_subnet := fmt.Sprintf("run%d", rand.Uint32())
-			DockerString(fmt.Sprintf("docker network create %s --subnet 192.169.0.0/16 -d calico --ipam-driver calico-ipam", name_subnet))
 			// Create a container that will just sit in the background
-			chosen_ip := "192.169.50.51"
-			DockerString(fmt.Sprintf("docker run --ip %s --net %s -tid --name %s %s", chosen_ip, name_subnet, name_subnet, os.Getenv("BUSYBOX_IMAGE") ))
+			chosen_ip := "192.170.50.51"
+			DockerString(fmt.Sprintf("docker run --ip %s --net %s -tid --name %s %s", chosen_ip, pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name_subnet, name_subnet)
-			ip := docker_endpoint.IPAddress
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name_subnet := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
+			dockerEndpoint := GetDockerEndpoint(name, pool)
+			ip := dockerEndpoint.IPAddress
+			mac := dockerEndpoint.MacAddress
+			endpointID := dockerEndpoint.EndpointID
+			vethName := "cali" + endpointID[:mathutils.MinInt(11, len(endpointID))]
 
 			Expect(ip).Should(Equal(chosen_ip))
 
 			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":["%s"],"ipv4_nets":["%s/32"],"ipv6_nets":[]}`,
-				interface_name_subnet, mac, name_subnet, ip)))
+			key := fmt.Sprintf("/calico/resources/v3/projectcalico.org/workloadendpoints/libnetwork/test-libnetwork-libnetwork-%s", endpointID)
+			endpointJSON := GetEtcd(key)
+			wep := api.NewWorkloadEndpoint()
+			json.Unmarshal(endpointJSON, &wep)
+			Expect(wep.Spec.InterfaceName).Should(Equal(vethName))
 
 			// Check the interface exists on the Host - it has an autoassigned
 			// mac and ip, so don't check anything!
-			DockerString(fmt.Sprintf("ip addr show %s", interface_name_subnet))
+			DockerString(fmt.Sprintf("ip addr show %s", vethName))
 
 			// Make sure the interface in the container exists and has the  assigned ip and mac
-			container_interface_string := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name_subnet))
-			Expect(container_interface_string).Should(ContainSubstring(ip))
-			Expect(container_interface_string).Should(ContainSubstring(mac))
+			containerNICString := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name))
+			Expect(containerNICString).Should(ContainSubstring(ip))
+			Expect(containerNICString).Should(ContainSubstring(mac))
 
 			// Make sure the container has the routes we expect
-			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name_subnet))
+			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
 			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
-
-			// Delete container and network
-			DockerString(fmt.Sprintf("docker rm -f %s", name_subnet))
-			DockerString(fmt.Sprintf("docker network rm %s", name_subnet))
-		})
-
-		It("creates a container in network with a subnet", func() {
-			name_subnet := fmt.Sprintf("run%d", rand.Uint32())
-			DockerString(fmt.Sprintf("docker network create %s --subnet 192.169.0.0/16 -d calico --ipam-driver calico-ipam", name_subnet))
-			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", name_subnet, name_subnet, os.Getenv("BUSYBOX_IMAGE") ))
-
-			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name_subnet, name_subnet)
-			ip := docker_endpoint.IPAddress
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name_subnet := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
-
-			Expect(ip).Should(HavePrefix("192.169."))
-
-			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":["%s"],"ipv4_nets":["%s/32"],"ipv6_nets":[]}`,
-				interface_name_subnet, mac, name_subnet, ip)))
-
-			// Check the interface exists on the Host - it has an autoassigned
-			// mac and ip, so don't check anything!
-			DockerString(fmt.Sprintf("ip addr show %s", interface_name_subnet))
-
-			// Make sure the interface in the container exists and has the  assigned ip and mac
-			container_interface_string := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name_subnet))
-			Expect(container_interface_string).Should(ContainSubstring(ip))
-			Expect(container_interface_string).Should(ContainSubstring(mac))
-
-			// Make sure the container has the routes we expect
-			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name_subnet))
-			Expect(routes).Should(Equal("default via 169.254.1.1 dev cali0 \n169.254.1.1 dev cali0 scope link"))
-
-			// Delete container and network
-			DockerString(fmt.Sprintf("docker rm -f %s", name_subnet))
-			DockerString(fmt.Sprintf("docker network rm %s", name_subnet))
 		})
 
 		It("creates a container with labels, but do not expect those in endpoint", func() {
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --label not=expected --label org.projectcalico.label.foo=bar --label org.projectcalico.label.baz=quux --name %s %s", pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name, name)
-			ip := docker_endpoint.IPAddress
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
+			dockerEndpoint := GetDockerEndpoint(name, pool)
+			endpointID := dockerEndpoint.EndpointID
+			vethName := "cali" + endpointID[:mathutils.MinInt(11, len(endpointID))]
+
+			// Sleep to allow the plugin to query the started container and update the WEP
+			// Alternative: query etcd until we hit jackpot or timeout
+			time.Sleep(time.Second)
 
 			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":["%s"],"ipv4_nets":["%s/32"],"ipv6_nets":[]}`,
-				interface_name, mac, name, ip)))
-
-			// Delete container
-			DockerString(fmt.Sprintf("docker rm -f %s", name))
+			key := fmt.Sprintf("/calico/resources/v3/projectcalico.org/workloadendpoints/libnetwork/test-libnetwork-libnetwork-%s", endpointID)
+			endpointJSON := GetEtcd(key)
+			wep := api.NewWorkloadEndpoint()
+			json.Unmarshal(endpointJSON, &wep)
+			Expect(wep.Spec.InterfaceName).Should(Equal(vethName))
+			_, ok := wep.ObjectMeta.Labels["foo"]
+			Expect(ok).Should(Equal(false))
+			_, ok = wep.ObjectMeta.Labels["baz"]
+			Expect(ok).Should(Equal(false))
+			_, ok = wep.ObjectMeta.Labels["not"]
+			Expect(ok).Should(Equal(false))
 		})
-
 	})
 
 	Describe("docker run ipv6", func() {
 		var name string
+		var pool string
+
 		BeforeEach(func() {
 			name = fmt.Sprintf("run%d", rand.Uint32())
-			DockerString(fmt.Sprintf("docker network create --ipv6 %s -d calico --ipam-driver calico-ipam", name))
-		})
-		AfterEach(func() {
-			DockerString(fmt.Sprintf("docker network rm %s", name))
+			pool = fmt.Sprintf("test6p%d", rand.Uint32())
+			subnet := "fdb7:472d:ff0b::/48"
+			CreatePool(pool, subnet)
+			nid := DockerString(fmt.Sprintf("docker network create --driver calico --ipam-driver calico-ipam --subnet %s --ipv6 %s ", subnet, pool))
+			UpdatePool(pool, subnet, nid)
 		})
 
-		It("creates a container on a network  and checks all assertions", func() {
+		AfterEach(func() {
+			DockerString(fmt.Sprintf("docker rm -f %s", name))
+			DockerString(fmt.Sprintf("docker network rm %s", pool))
+		})
+
+		It("creates a container on a network and checks all assertions", func() {
 			// Create a container that will just sit in the background
-			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", name, name, os.Getenv("BUSYBOX_IMAGE") ))
+			DockerString(fmt.Sprintf("docker run --net %s -tid --name %s %s", pool, name, os.Getenv("BUSYBOX_IMAGE")))
 
 			// Gather information for assertions
-			docker_endpoint := GetDockerEndpoint(name, name)
-			ip := docker_endpoint.IPAddress
-			ipv6 := docker_endpoint.GlobalIPv6Address
-			mac := docker_endpoint.MacAddress
-			endpoint_id := docker_endpoint.EndpointID
-			interface_name := "cali" + endpoint_id[:mathutils.MinInt(11, len(endpoint_id))]
+			dockerEndpoint := GetDockerEndpoint(name, pool)
+			ipv6 := dockerEndpoint.GlobalIPv6Address
+			mac := dockerEndpoint.MacAddress
+			endpointID := dockerEndpoint.EndpointID
+			vethName := "cali" + endpointID[:mathutils.MinInt(11, len(endpointID))]
 
 			// Check that the endpoint is created in etcd
-			etcd_endpoint := GetEtcdString(fmt.Sprintf("/calico/v1/host/test/workload/libnetwork/libnetwork/endpoint/%s", endpoint_id))
-			Expect(etcd_endpoint).Should(MatchJSON(fmt.Sprintf(
-				`{"state":"active","name":"%s","active_instance_id":"","mac":"%s","profile_ids":["%s"],"ipv4_nets":["%s/32"],"ipv6_nets":["%s/128"]}`,
-				interface_name, mac, name, ip, ipv6)))
+			key := fmt.Sprintf("/calico/resources/v3/projectcalico.org/workloadendpoints/libnetwork/test-libnetwork-libnetwork-%s", endpointID)
+			endpointJSON := GetEtcd(key)
+			wep := api.NewWorkloadEndpoint()
+			json.Unmarshal(endpointJSON, &wep)
+			Expect(wep.Spec.InterfaceName).Should(Equal(vethName))
 
 			// Check the interface exists on the Host - it has an autoassigned
 			// mac and ip, so don't check anything!
-			DockerString(fmt.Sprintf("ip addr show %s", interface_name))
-			DockerString(fmt.Sprintf("ip -6 addr show %s", interface_name))
+			DockerString(fmt.Sprintf("ip addr show %s", vethName))
+			DockerString(fmt.Sprintf("ip -6 addr show %s", vethName))
 
-			// Make sure the interface in the container exists and has the  assigned ipv6 and mac
-			container_interface_string := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name))
-			Expect(container_interface_string).Should(ContainSubstring(ipv6))
-			Expect(container_interface_string).Should(ContainSubstring(mac))
+			// Make sure the interface in the container exists and has the  assigned ip and mac
+			containerNICString := DockerString(fmt.Sprintf("docker exec -i %s ip addr", name))
+			Expect(containerNICString).Should(ContainSubstring(ipv6))
+			Expect(containerNICString).Should(ContainSubstring(mac))
 
 			// Make sure the container has the routes we expect
 			routes := DockerString(fmt.Sprintf("docker exec -i %s ip route", name))
@@ -375,10 +350,8 @@ var _ = Describe("Libnetwork Tests", func() {
 			routes6 := DockerString(fmt.Sprintf("docker exec -i %s ip -6 route", name))
 			Expect(routes6).Should(MatchRegexp("default via fe80::.* dev cali0  metric 1024"))
 
-			// Delete container
-			DockerString(fmt.Sprintf("docker rm -f %s", name))
 		})
 	})
-	//Docker stop/rm - stop and rm are the same as far as the plugin is concerned
+	//docker stop/rm - stop and rm are the same as far as the plugin is concerned
 	// TODO - check that the endpoint is removed from etcd and that the  veth is removed
 })


### PR DESCRIPTION
## Description

This PR make this plugin support calico v3, so we can use latest calicoctl manage now.  In this PR I do those things:

* use latest libcalico to implement ipam and network driver.
* set docker network endpoint in ippool's meta, thus we can find it without query docker api ( this will cause problem when system restart and plugin run in docker, both of docker and plugin were waiting each other)
* use hostname as default namespace, it's better when you have huge containers.
* tested fully and manually.
* I disable some tests because useless now. I think tests can cover whole cases.

