### PR TITLE
Add standard ci and cd targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,26 @@ ifndef IMAGETAG
 	$(error IMAGETAG is undefined - run using make <target> IMAGETAG=X.Y.Z)
 endif
 
+
+###############################################################################
+# CI/CD
+###############################################################################
+.PHONY: ci cd
+## Builds the code and runs all tests.
+ci: image test-containerized
+
+## Deploys images to registry
+cd:
+ifndef CONFIRM
+	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
+endif
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
+endif
+	$(MAKE) tag-images push IMAGETAG=${BRANCH_NAME}
+	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+
+
 ###############################################################################
 # tag and push images of any tag
 ###############################################################################


### PR DESCRIPTION
Standard `ci` and `cd` targets to replace the messy one-liner scripts in Semaphore. Per all of the other projects.

```release-note
None required
```